### PR TITLE
Updated param types

### DIFF
--- a/packages/core/src/types/v3/PaginatedResults.ts
+++ b/packages/core/src/types/v3/PaginatedResults.ts
@@ -1,0 +1,5 @@
+export interface PaginatedResponse {
+    page: number;
+    total_results: number;
+    total_pages: number;
+}

--- a/packages/core/src/types/v3/search/multi-search.ts
+++ b/packages/core/src/types/v3/search/multi-search.ts
@@ -1,8 +1,9 @@
-export interface SearchMultiSearchResponse {
-  page: number;
+import {PaginatedResponse} from '../PaginatedResults';
+
+
+
+export interface SearchMultiSearchResponse extends PaginatedResponse {
   results: SearchMultiSearchResult[];
-  total_results: number;
-  total_pages: number;
 }
 
 export interface SearchMultiSearchResult {

--- a/packages/core/src/types/v3/search/search-collections.ts
+++ b/packages/core/src/types/v3/search/search-collections.ts
@@ -1,11 +1,4 @@
-import PaginatedResponse from "../PaginatedResults"
-
-//export interface SearchCollectionsResponse {
-//  page: number;
-//  results: SearchCollectionsResult[];
-//  total_pages: number;
-//  total_results: number;
-//}
+import {PaginatedResponse} from "../PaginatedResults";
 
 export interface SearchCollectionsResponse extends PaginatedResponse {
     results: SearchCollectionsResult[];

--- a/packages/core/src/types/v3/search/search-collections.ts
+++ b/packages/core/src/types/v3/search/search-collections.ts
@@ -1,19 +1,31 @@
-export interface SearchCollectionsResponse {
-  page: number;
-  results: SearchCollectionsResult[];
-  total_pages: number;
-  total_results: number;
+import PaginatedResponse from "../PaginatedResults"
+
+//export interface SearchCollectionsResponse {
+//  page: number;
+//  results: SearchCollectionsResult[];
+//  total_pages: number;
+//  total_results: number;
+//}
+
+export interface SearchCollectionsResponse extends PaginatedResponse {
+    results: SearchCollectionsResult[];
 }
 
 export interface SearchCollectionsResult {
+  adult: boolean;
   id: number;
   name: string;
+  original_language: string;
+  original_name: string;
+  overview: string;
   poster_path: null | string;
   backdrop_path: null | string;
 }
 
 export interface SearchCollectionsParams {
   query: string;
+  include_adult?: boolean;
   page?: number;
   language?: string;
+  region?: string;
 }

--- a/packages/core/src/types/v3/search/search-companies.ts
+++ b/packages/core/src/types/v3/search/search-companies.ts
@@ -1,14 +1,13 @@
-export interface SearchCompaniesResponse {
-  page: number;
+import { PaginatedResponse } from '../PaginatedResults';
+export interface SearchCompaniesResponse extends PaginatedResponse {
   results: SearchCompaniesResult[];
-  total_pages: number;
-  total_results: number;
 }
 
 export interface SearchCompaniesResult {
   id: number;
   logo_path: null | string;
   name: string;
+  origin_country: string;
 }
 
 export interface SearchCompaniesParams {

--- a/packages/core/src/types/v3/search/search-keywords.ts
+++ b/packages/core/src/types/v3/search/search-keywords.ts
@@ -1,8 +1,7 @@
-export interface SearchKeywordsResponse {
-  page: number;
+import { PaginatedResponse } from "../PaginatedResults";
+
+export interface SearchKeywordsResponse extends PaginatedResponse {
   results: SearchKeywordsResult[];
-  total_pages: number;
-  total_results: number;
 }
 
 export interface SearchKeywordsResult {

--- a/packages/core/src/types/v3/search/search-movies.ts
+++ b/packages/core/src/types/v3/search/search-movies.ts
@@ -1,8 +1,7 @@
-export interface SearchMoviesResponse {
-  page: number;
+import { PaginatedResponse } from "../PaginatedResults";
+
+export interface SearchMoviesResponse extends PaginatedResponse {
   results: SearchMoviesResult[];
-  total_results: number;
-  total_pages: number;
 }
 
 export interface SearchMoviesResult {

--- a/packages/core/src/types/v3/search/search-people.ts
+++ b/packages/core/src/types/v3/search/search-people.ts
@@ -1,16 +1,18 @@
-export interface SearchPeopleResponse {
-  page: number;
+import { PaginatedResponse } from "../PaginatedResults";
+
+export interface SearchPeopleResponse extends PaginatedResponse {
   results: SearchPeopleResult[];
-  total_results: number;
-  total_pages: number;
 }
 
 export interface SearchPeopleResult {
   profile_path: null | string;
   adult: boolean;
+  gender: number;
   id: number;
+  known_for_department: string;
   known_for: SearchPeopleKnownFor[];
   name: string;
+  original_name: string;
   popularity: number;
 }
 

--- a/packages/core/src/types/v3/search/search-tvshows.ts
+++ b/packages/core/src/types/v3/search/search-tvshows.ts
@@ -1,11 +1,11 @@
-export interface SearchTVShowsResponse {
-  page: number;
+import { PaginatedResponse } from "../PaginatedResults";
+
+export interface SearchTVShowsResponse extends PaginatedResponse {
   results: SearchTVShowsResult[];
-  total_results: number;
-  total_pages: number;
 }
 
 export interface SearchTVShowsResult {
+  adult: boolean;
   poster_path: string;
   popularity: number;
   id: number;
@@ -27,4 +27,5 @@ export interface SearchTVShowsParams {
   page?: number;
   include_adult?: boolean;
   first_air_date_year?: number;
+  year?: string;
 }


### PR DESCRIPTION
Added  missing fields to the interfaces/types used for the returned objects returned from the /search/ endpoints.  Added a interface/type for the paginated results that contains common paginated fields, so other types that use those fields can just extend that interface. 