### PR TITLE
Append to response type issues

### DIFF
--- a/.changeset/breezy-avocados-pay.md
+++ b/.changeset/breezy-avocados-pay.md
@@ -1,0 +1,6 @@
+---
+"tmdb-js-node": patch
+"tmdb-js-web": patch
+---
+
+Fix wrong return type when supplying an append_to_response array for some functions, thanks @newmoneybigbucks!

--- a/.changeset/tasty-hairs-float.md
+++ b/.changeset/tasty-hairs-float.md
@@ -1,7 +1,0 @@
----
-"tmdb-js-core": patch
----
-
-AppendToResponseType and ResponseTypeFor would add response types for MovieAppendToResponseType to all other ever other type if the key for a particular append to reponse type also existed in MovieAppendToReponse.
-
-Changes were made to those types and to the get details functions that used append to reponse  so that the expected type information would be passed into ResponseTypeFor and the correct type would be retreived

--- a/.changeset/tasty-hairs-float.md
+++ b/.changeset/tasty-hairs-float.md
@@ -2,8 +2,6 @@
 "tmdb-js-core": patch
 ---
 
-
 AppendToResponseType and ResponseTypeFor would add response types for MovieAppendToResponseType to all other ever other type if the key for a particular append to reponse type also existed in MovieAppendToReponse.
 
-Changes were made to those types and to the functions that hand append to reponse so that the expected type information would be passed into ResponseTypeFor and the correct type would be retreived 
-
+Changes were made to those types and to the get details functions that used append to reponse  so that the expected type information would be passed into ResponseTypeFor and the correct type would be retreived

--- a/.changeset/tasty-hairs-float.md
+++ b/.changeset/tasty-hairs-float.md
@@ -1,0 +1,9 @@
+---
+"tmdb-js-core": patch
+---
+
+
+AppendToResponseType and ResponseTypeFor would add response types for MovieAppendToResponseType to all other ever other type if the key for a particular append to reponse type also existed in MovieAppendToReponse.
+
+Changes were made to those types and to the functions that hand append to reponse so that the expected type information would be passed into ResponseTypeFor and the correct type would be retreived 
+

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-    "printWidth": 200
+  "printWidth": 200,
+  "endOfLine": "crlf"
 }

--- a/packages/core/src/types/append-to-response.ts
+++ b/packages/core/src/types/append-to-response.ts
@@ -167,19 +167,34 @@ export interface TVEpisodesAppendToResponseTypes {
 }
 
 type ResponseTypes = "movie" | "tv" | "people" | "tv_seasons" | "tv_episodes";
-type ResponseTypeFor<T, U> =
-  U extends "movie" ? (T extends keyof MoviesAppendToResponseTypes ? MoviesAppendToResponseTypes[T] : never) :
-    U extends "tv" ? (T extends keyof TVAppendToResponseTypes ? TVAppendToResponseTypes[T]: never) :
-      U extends "people" ? (T extends keyof PeopleAppendToResponseTypes ? PeopleAppendToResponseTypes[T]  : never) :
-        U extends "tv_seasons" ? ( T extends keyof TVSeasonsAppendToResponseTypes ? TVSeasonsAppendToResponseTypes[T] : never) :
-          U extends "tv_episodes" ? ( T extends keyof TVEpisodesAppendToResponseTypes ? TVEpisodesAppendToResponseTypes[T] : never)
-          : never ;
+type ResponseTypeFor<T, U> = U extends "movie"
+  ? T extends keyof MoviesAppendToResponseTypes
+    ? MoviesAppendToResponseTypes[T]
+    : never
+  : U extends "tv"
+  ? T extends keyof TVAppendToResponseTypes
+    ? TVAppendToResponseTypes[T]
+    : never
+  : U extends "people"
+  ? T extends keyof PeopleAppendToResponseTypes
+    ? PeopleAppendToResponseTypes[T]
+    : never
+  : U extends "tv_seasons"
+  ? T extends keyof TVSeasonsAppendToResponseTypes
+    ? TVSeasonsAppendToResponseTypes[T]
+    : never
+  : U extends "tv_episodes"
+  ? T extends keyof TVEpisodesAppendToResponseTypes
+    ? TVEpisodesAppendToResponseTypes[T]
+    : never
+  : never;
 
 type ExtractValidKeys<T> = T extends (infer U)[] ? U : never;
 
 export type AppendToResponseType<
   AppendToResponse extends (MoviesAppendToResponse | TVAppendToResponse | PeopleAppendToResponse | TVSeasonsAppendToResponse | TVEpisodesAppendToResponse)[] | undefined,
-ResponseType extends ResponseTypes> = AppendToResponse extends undefined
+  ResponseType extends ResponseTypes,
+> = AppendToResponse extends undefined
   ? Record<string, never>
   : {
       [K in ExtractValidKeys<AppendToResponse>]: ResponseTypeFor<K, ResponseType>;

--- a/packages/core/src/types/append-to-response.ts
+++ b/packages/core/src/types/append-to-response.ts
@@ -172,22 +172,22 @@ type ResponseTypeFor<T, U> = U extends "movie"
     ? MoviesAppendToResponseTypes[T]
     : never
   : U extends "tv"
-  ? T extends keyof TVAppendToResponseTypes
-    ? TVAppendToResponseTypes[T]
-    : never
-  : U extends "people"
-  ? T extends keyof PeopleAppendToResponseTypes
-    ? PeopleAppendToResponseTypes[T]
-    : never
-  : U extends "tv_seasons"
-  ? T extends keyof TVSeasonsAppendToResponseTypes
-    ? TVSeasonsAppendToResponseTypes[T]
-    : never
-  : U extends "tv_episodes"
-  ? T extends keyof TVEpisodesAppendToResponseTypes
-    ? TVEpisodesAppendToResponseTypes[T]
-    : never
-  : never;
+    ? T extends keyof TVAppendToResponseTypes
+      ? TVAppendToResponseTypes[T]
+      : never
+    : U extends "people"
+      ? T extends keyof PeopleAppendToResponseTypes
+        ? PeopleAppendToResponseTypes[T]
+        : never
+      : U extends "tv_seasons"
+        ? T extends keyof TVSeasonsAppendToResponseTypes
+          ? TVSeasonsAppendToResponseTypes[T]
+          : never
+        : U extends "tv_episodes"
+          ? T extends keyof TVEpisodesAppendToResponseTypes
+            ? TVEpisodesAppendToResponseTypes[T]
+            : never
+          : never;
 
 type ExtractValidKeys<T> = T extends (infer U)[] ? U : never;
 
@@ -197,5 +197,5 @@ export type AppendToResponseType<
 > = AppendToResponse extends undefined
   ? Record<string, never>
   : {
-      [K in ExtractValidKeys<AppendToResponse>]: ResponseTypeFor<K, ResponseType>;
-    };
+    [K in ExtractValidKeys<AppendToResponse>]: ResponseTypeFor<K, ResponseType>;
+  };

--- a/packages/core/src/types/append-to-response.ts
+++ b/packages/core/src/types/append-to-response.ts
@@ -166,24 +166,21 @@ export interface TVEpisodesAppendToResponseTypes {
   videos: TVEpisodesGetVideosResponse;
 }
 
-type ResponseTypeFor<T> = T extends keyof MoviesAppendToResponseTypes
-  ? MoviesAppendToResponseTypes[T]
-  : T extends keyof TVAppendToResponseTypes
-    ? TVAppendToResponseTypes[T]
-    : T extends keyof PeopleAppendToResponseTypes
-      ? PeopleAppendToResponseTypes[T]
-      : T extends keyof TVSeasonsAppendToResponseTypes
-        ? TVSeasonsAppendToResponseTypes[T]
-        : T extends keyof TVEpisodesAppendToResponseTypes
-          ? TVEpisodesAppendToResponseTypes[T]
-          : never;
+type ResponseTypes = "movie" | "tv" | "people" | "tv_seasons" | "tv_episodes";
+type ResponseTypeFor<T, U> =
+  U extends "movie" ? (T extends keyof MoviesAppendToResponseTypes ? MoviesAppendToResponseTypes[T] : never) :
+    U extends "tv" ? (T extends keyof TVAppendToResponseTypes ? TVAppendToResponseTypes[T]: never) :
+      U extends "people" ? (T extends keyof PeopleAppendToResponseTypes ? PeopleAppendToResponseTypes[T]  : never) :
+        U extends "tv_seasons" ? ( T extends keyof TVSeasonsAppendToResponseTypes ? TVSeasonsAppendToResponseTypes[T] : never) :
+          U extends "tv_episodes" ? ( T extends keyof TVEpisodesAppendToResponseTypes ? TVEpisodesAppendToResponseTypes[T] : never)
+          : never ;
 
 type ExtractValidKeys<T> = T extends (infer U)[] ? U : never;
 
 export type AppendToResponseType<
   AppendToResponse extends (MoviesAppendToResponse | TVAppendToResponse | PeopleAppendToResponse | TVSeasonsAppendToResponse | TVEpisodesAppendToResponse)[] | undefined,
-> = AppendToResponse extends undefined
+ResponseType extends ResponseTypes> = AppendToResponse extends undefined
   ? Record<string, never>
   : {
-      [K in ExtractValidKeys<AppendToResponse>]: ResponseTypeFor<K>;
+      [K in ExtractValidKeys<AppendToResponse>]: ResponseTypeFor<K, ResponseType>;
     };

--- a/packages/core/src/types/append-to-response.ts
+++ b/packages/core/src/types/append-to-response.ts
@@ -197,5 +197,5 @@ export type AppendToResponseType<
 > = AppendToResponse extends undefined
   ? Record<string, never>
   : {
-    [K in ExtractValidKeys<AppendToResponse>]: ResponseTypeFor<K, ResponseType>;
-  };
+      [K in ExtractValidKeys<AppendToResponse>]: ResponseTypeFor<K, ResponseType>;
+    };

--- a/packages/core/src/types/v3/movies/get-details.ts
+++ b/packages/core/src/types/v3/movies/get-details.ts
@@ -56,4 +56,4 @@ export interface MoviesGetDetailsParams<T extends MoviesAppendToResponse[]> {
   append_to_response?: T;
 }
 
-export type MoviesGetDetailsResponse<AppendToResponse extends MoviesAppendToResponse[] | undefined> = MoviesGetDetailsBaseResponse & AppendToResponseType<AppendToResponse>;
+export type MoviesGetDetailsResponse<AppendToResponse extends MoviesAppendToResponse[] | undefined> = MoviesGetDetailsBaseResponse & AppendToResponseType<AppendToResponse, "movie">;

--- a/packages/core/src/types/v3/people/get-details.ts
+++ b/packages/core/src/types/v3/people/get-details.ts
@@ -22,4 +22,4 @@ export interface PeopleGetDetailsParams<T extends PeopleAppendToResponse[]> {
   append_to_response?: T;
 }
 
-export type PeopleGetDetailsResponse<AppendToResponse extends PeopleAppendToResponse[] | undefined> = PeopleGetDetailsBaseResponse & AppendToResponseType<AppendToResponse>;
+export type PeopleGetDetailsResponse<AppendToResponse extends PeopleAppendToResponse[] | undefined> = PeopleGetDetailsBaseResponse & AppendToResponseType<AppendToResponse, "people">;

--- a/packages/core/src/types/v3/tv-episodes/get-details.ts
+++ b/packages/core/src/types/v3/tv-episodes/get-details.ts
@@ -49,4 +49,4 @@ export interface TVEpisodesGetDetailsParams<T extends TVEpisodesAppendToResponse
   append_to_response?: T;
 }
 
-export type TVEpisodesGetDetailsResponse<AppendToResponse extends TVEpisodesAppendToResponse[] | undefined> = TVEpisodesGetDetailsBaseResponse & AppendToResponseType<AppendToResponse>;
+export type TVEpisodesGetDetailsResponse<AppendToResponse extends TVEpisodesAppendToResponse[] | undefined> = TVEpisodesGetDetailsBaseResponse & AppendToResponseType<AppendToResponse, "tv_episodes">;

--- a/packages/core/src/types/v3/tv-seasons/get-details.ts
+++ b/packages/core/src/types/v3/tv-seasons/get-details.ts
@@ -49,6 +49,3 @@ export interface TVSeasonsGetDetailsParams<T extends TVSeasonsAppendToResponse[]
 }
 
 export type TVSeasonsGetDetailsResponse<AppendToResponse extends TVSeasonsAppendToResponse[] | undefined> = TVSeasonsGetDetailsBaseResponse & AppendToResponseType<AppendToResponse, "tv_seasons">;
-
-
-

--- a/packages/core/src/types/v3/tv-seasons/get-details.ts
+++ b/packages/core/src/types/v3/tv-seasons/get-details.ts
@@ -1,5 +1,4 @@
 import { AppendToResponseType, TVSeasonsAppendToResponse } from "../../append-to-response";
-
 export interface TVSeasonsGetDetailsBaseResponse {
   _id: string;
   air_date: string;
@@ -49,4 +48,7 @@ export interface TVSeasonsGetDetailsParams<T extends TVSeasonsAppendToResponse[]
   append_to_response?: T;
 }
 
-export type TVSeasonsGetDetailsResponse<AppendToResponse extends TVSeasonsAppendToResponse[] | undefined> = TVSeasonsGetDetailsBaseResponse & AppendToResponseType<AppendToResponse>;
+export type TVSeasonsGetDetailsResponse<AppendToResponse extends TVSeasonsAppendToResponse[] | undefined> = TVSeasonsGetDetailsBaseResponse & AppendToResponseType<AppendToResponse, "tv_seasons">;
+
+
+

--- a/packages/core/src/types/v3/tv/get-details.ts
+++ b/packages/core/src/types/v3/tv/get-details.ts
@@ -93,4 +93,4 @@ export interface TVGetDetailsParams<T extends TVAppendToResponse[]> {
   append_to_response?: T;
 }
 
-export type TVGetDetailsResponse<AppendToResponse extends TVAppendToResponse[] | undefined> = TVGetDetailsBaseResponse & AppendToResponseType<AppendToResponse>;
+export type TVGetDetailsResponse<AppendToResponse extends TVAppendToResponse[] | undefined> = TVGetDetailsBaseResponse & AppendToResponseType<AppendToResponse, "tv">;


### PR DESCRIPTION
AppendToResopnseType and ResponseTypeFor had an issue where if there was a key shared among all the append to response types  only the types found in  MoviesAppendToReponseTypes would be used since ReponseTypeFor had that type first in its set of conditionals. 
I added some code to add string literals to use as type information/a discriminant so AppendToResponseType type now takes a string literal (the functions that use the type pass the appropriate literal) and passes this to ReponseType which uses it to retrieve the correct set of types instead of just MoviesAppendToResponseTypes